### PR TITLE
Handle exceptions in shipping method rate calculation

### DIFF
--- a/src/Plugin/Field/FieldWidget/ShippingRateWidget.php
+++ b/src/Plugin/Field/FieldWidget/ShippingRateWidget.php
@@ -91,7 +91,17 @@ class ShippingRateWidget extends WidgetBase implements ContainerFactoryPluginInt
     $options = [];
     foreach ($shipping_methods as $shipping_method) {
       $shipping_method_plugin = $shipping_method->getPlugin();
-      $shipping_rates = $shipping_method_plugin->calculateRates($shipment);
+      try {
+        $shipping_rates = $shipping_method_plugin->calculateRates($shipment);
+      }
+      catch (\Exception $e) {
+        \Drupal::logger('commerce_shipping')
+          ->error(t('Rate calculation failed for @name: @message', [
+            '@name' => $shipping_method->getName(),
+            '@message' => $e->getMessage(),
+          ]);
+        continue;
+      }
       foreach ($shipping_rates as $shipping_rate) {
         $service = $shipping_rate->getService();
         $amount = $shipping_rate->getAmount();


### PR DESCRIPTION
Addresses d.o issue #3017776 https://www.drupal.org/project/commerce_shipping/issues/3017776:

Setup:
* 2 shipping methods enabled, Fedex and USPS
* USPS working propertly
* Fedex failing (bug filed separately)

Expectation:
* USPS shipping method will still be displayed
* Fedex failure logged

Observed:
* No shipping methods displayed, user cannot proceed to checkout